### PR TITLE
chore: set up basic pipeline for repo workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: "\U0001F41B Bug Report"
+about: Report a bug
+title: "🐛 Bug: "
+labels: bug, needs-triage
+---
+
+<!-- description of the bug: -->
+
+### Reproduction Steps
+
+<!-- how to reproduce the bug in code -->
+
+### What is happening?
+
+<!-- What is the behavior you were seeing? If you got an error, paste it here. -->
+
+
+### Suggestions
+
+<!-- e.g. detailed explanation, suggestions on how to fix, eg. associated pull-request, stackoverflow, etc -->
+
+
+--- 
+
+This is a :bug: Bug Report

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F680 Feature Request"
+about: Requesting a new feature
+title: "🚀 Feature: "
+labels: feature, needs-triage
+---
+
+<!-- short description of the feature -->
+
+
+### Use Case
+
+<!-- why do you need this feature? -->
+
+
+### Proposed Solution
+
+<!-- Please include prototype/sketch/reference implementation: -->
+
+
+* [ ] :wave: I may be able to implement this feature request
+
+---
+
+This is a :rocket: Feature Request

--- a/.github/ISSUE_TEMPLATE/tracking.md
+++ b/.github/ISSUE_TEMPLATE/tracking.md
@@ -1,0 +1,24 @@
+---
+name: "👀 Tracking Issue"
+title: "👀 Tracking: "
+about: add a subject to track
+labels: tracking
+---
+
+### Overview:
+<!-- A summary of the subject you are tracking -->
+
+### Design & Implementation:
+<!-- 
+Designs, code snippets, or dicussion revolved around the subject
+-->
+
+### Checklist:
+<!-- 
+e.g. checklist of links to feature requests, bugs, and PRs that are in scope for release
+- [ ] 
+- [ ]
+-->
+
+--- 
+This is a 👀 Tracking Issue

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,16 @@
+# For Semantic Pull Request
+titleOnly: true
+
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+  - release

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,13 @@
+# Mergify Rules
+# 1. Conventional Commits
+# 2. Automatic merge + squash
+# 3. Automatic merge
+# 4. Remove stale reviews
+# 5. Dependabot
+
 pull_request_rules:
+
+  # 1. Check title to follow conventional commits
   - name: if fails conventional commits
     actions:
       comment:
@@ -9,7 +18,9 @@ pull_request_rules:
       - status-failure=Semantic Pull Request
       - -merged
       - -closed
-  - name: automatic merge and squasb
+  
+  # 2. Automatically merge master into branch, build, and squash
+  - name: automatic merge and squash
     actions:
       comment:
         message: Thanks for contributing! Your pull request will be updated from master and then merged automatically (do not update manually, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
@@ -29,10 +40,12 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
       - "#changes-requested-reviews-by=0"
+  
+  # 3. Automatically merge master into branch and build
   - name: automatic merge
     actions:
       comment:
-        message: Thank you for contributing! Your pull request will be updated from master and then merged automatically without squashing (do not update manually, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+        message: Thank you for contributing! Your pull request will be updated from master and then merged automatically (do not update manually, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
       merge:
         strict: smart
         # Merge instead of squash
@@ -51,6 +64,8 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
       - "#changes-requested-reviews-by=0"
+  
+  # 4. Dismiss reviews that are stale/merged
   - name: remove stale reviews
     actions:
       dismiss_reviews:
@@ -59,14 +74,15 @@ pull_request_rules:
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]
-      - label!=contribution/core
       - base=master
       - -merged
       - -closed
-  - name: automatic merge of Dependabot PRs
+  
+  # 5. Automatically merge dependabot's blessed PRs
+  - name: automatically merge Dependabot PRs
     actions:
       comment:
-        message: Thanks Dependabot!
+        message: Thanks Dependabot 🙏!
       merge:
         # 'strict: false' disables Mergify keeping the branch up-to-date from master.
         # It's not necessary: Dependabot will do that itself.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,84 @@
+pull_request_rules:
+  - name: if fails conventional commits
+    actions:
+      comment:
+        message: Title does not follow the guidelines of [Conventional Commits](https://www.conventionalcommits.org). Please adjust title before merge.
+    conditions:
+      - author!=dependabot[bot]
+      - author!=dependabot-preview[bot]
+      - status-failure=Semantic Pull Request
+      - -merged
+      - -closed
+  - name: automatic merge and squasb
+    actions:
+      comment:
+        message: Thanks for contributing! Your pull request will be updated from master and then merged automatically (do not update manually, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+      merge:
+        strict: smart
+        method: squash
+        strict_method: merge
+        commit_message: title+body
+      delete_head_branch: {}
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=(work-in-progress|do-not-merge|no-squash)
+      - -merged
+      - -closed
+      - author!=dependabot[bot]
+      - author!=dependabot-preview[bot]
+      - "#approved-reviews-by>=1"
+      - -approved-reviews-by~=author
+      - "#changes-requested-reviews-by=0"
+  - name: automatic merge
+    actions:
+      comment:
+        message: Thank you for contributing! Your pull request will be updated from master and then merged automatically without squashing (do not update manually, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+      merge:
+        strict: smart
+        # Merge instead of squash
+        method: merge
+        strict_method: merge
+        commit_message: title+body
+      delete_head_branch: {}
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=(work-in-progress|do-not-merge)
+      - label~=no-squash
+      - -merged
+      - -closed
+      - author!=dependabot[bot]
+      - author!=dependabot-preview[bot]
+      - "#approved-reviews-by>=1"
+      - -approved-reviews-by~=author
+      - "#changes-requested-reviews-by=0"
+  - name: remove stale reviews
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: true
+    conditions:
+      - author!=dependabot[bot]
+      - author!=dependabot-preview[bot]
+      - label!=contribution/core
+      - base=master
+      - -merged
+      - -closed
+  - name: automatic merge of Dependabot PRs
+    actions:
+      comment:
+        message: Thanks Dependabot!
+      merge:
+        # 'strict: false' disables Mergify keeping the branch up-to-date from master.
+        # It's not necessary: Dependabot will do that itself.
+        # It's not dangerous: GitHub branch protection settings prevent merging stale branches.
+        strict: false
+        method: squash
+      delete_head_branch: {}
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=(work-in-progress|do-not-merge)
+      - -merged
+      - -closed
+      - author~=dependabot
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -1,0 +1,3 @@
+# Design Guidelines
+
+TODO.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Creative Labs Website Redesign
+# Creative Labs Website
+
+A place full of cool stuff, things, and peeps.
 
 ## Getting Started
 
@@ -6,4 +8,4 @@ TODO.
 
 ## Contributing
 
-TODO. See [CONTRIBUTING.md](CONTRIBUTING.md) for more info.
+TODO. See [CONTRIBUTING.md](CONTRIBUTING.md) and [DESIGN_GUIDELINES.md](DESIGN_GUIDELINES.md) for more info.


### PR DESCRIPTION
added design guidelines file

Set up basic pipeline for `sunshine-redesign`:
- [x] mergify
- [x] make labels for issues
- [x] issue templates for feat, bugs, chore, design
- [x] generate empty CONTRIBUTING.md
- [x] generate empty DESIGN_GUIDELINE.md

Fixes #13